### PR TITLE
Allow straight RegExp arguments

### DIFF
--- a/src/validator.js
+++ b/src/validator.js
@@ -777,7 +777,7 @@
         throw new Error( 'You must give a regexp' );
 
       this.regexp = regexp;
-      this.flag = flag || '';
+      this.flag = flag;
 
       this.validate = function ( value ) {
         if ( 'string' !== typeof value )

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -422,10 +422,15 @@ var Suite = function ( Validator, expect, extras ) {
         assert = new Assert().Regexp( '^[A-Z]' );
 
         expect( validate( 'foo', assert ) ).not.to.be( true );
-        expect( validate( 'foo', assert ).show() ).to.eql( { assert: 'Regexp', value: 'foo', violation: { regexp: '^[A-Z]', flag: '' } } );
+        expect( validate( 'foo', assert ).show() ).to.eql( { assert: 'Regexp', value: 'foo', violation: { regexp: '^[A-Z]', flag: undefined } } );
         expect( validate( 'FOO', assert ) ).to.be( true );
 
         assert = new Assert().Regexp( '^[A-Z]', 'i' );
+
+        expect( validate( 'foo', assert ) ).to.be( true );
+        expect( validate( 'FOO', assert ) ).to.be( true );
+
+        assert = new Assert().Regexp( /^[A-Z]/i );
 
         expect( validate( 'foo', assert ) ).to.be( true );
         expect( validate( 'FOO', assert ) ).to.be( true );


### PR DESCRIPTION
Would be nice to allow giving straight regexp for RegExp validations.