### PR TITLE
Catch errors in callback functions

### DIFF
--- a/src/validator.js
+++ b/src/validator.js
@@ -449,7 +449,13 @@
       this.fn = fn;
 
       this.validate = function ( value ) {
-        var result = this.fn.apply( this, [ value ].concat( this.arguments ) );
+        var result;
+        try {
+          result = this.fn.apply( this, [ value ].concat( this.arguments ) );
+        }
+        catch(err) {
+          throw new Violation( this, value, { error: err } );
+        }
 
         if ( true !== result )
           throw new Violation( this, value, { result: result } );

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -260,6 +260,18 @@ var Suite = function ( Validator, expect, extras ) {
         expect( validate( 'foo', assert ) ).to.be( true );
       } )
 
+      it( 'Callback with error in function', function () {
+        assert = new Assert().Callback( function ( value ) {
+          this_function_does_not_exist();
+        } );
+
+        var r = validate( 3, assert ).show();
+        expect(r.violation).not.to.be(undefined);
+        expect(r.violation.error).to.be.an(ReferenceError);
+        expect('' + r.violation.error).to.be( "ReferenceError: this_function_does_not_exist is not defined" );
+        expect(r).to.eql( { assert: 'Callback', value: 3, violation: { error: r.violation.error } } );
+      } )
+
       it( 'Choice', function () {
         assert = new Assert().Choice( [ 'foo', 'bar', 'baz' ] );
 


### PR DESCRIPTION
I'm not too sure how to best handle [this issue](https://github.com/guillaumepotier/Parsley.js/issues/867), but a relatively simple solution is to change `Callback` to throw a `Violation` in case an error occurs while executing the callback.
Let me know!