### PR TITLE
Modify Length validator to match length exactly against a specified value

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,8 +55,8 @@ Validator = require( 'validator.js' );
 ```js
 var Assert = Validator.Assert;
 
-Validator.Validator().validate( 'foo', new Assert().Length( { min: 4 } ) );
-Validator.Validator().validate( 'foo', [ new Assert().Length( { min: 4 } ), new Assert().Email() ] );
+Validator.Validator().validate( 'foo', new Assert().Range( 4, Number.MAX_VALUE ) );
+Validator.Validator().validate( 'foo', [ new Assert().Range( 4, Number.MAX_VALUE ), new Assert().Email() ] );
 
 ```
 will return `true` if validation passes, a `Violation`'s array otherwise.
@@ -74,7 +74,7 @@ var object = {
     phone: null
   },
   constraint = {
-    name:      [ new Assert().NotBlank(), new Assert().Length( { min: 4, max: 25 } ) ],
+    name:      [ new Assert().NotBlank(), new Assert().Range( 4, 25 ) ],
     email:     new Assert().Email(),
     firstname: new Assert().NotBlank(),
     phone:     new Assert().NotBlank()
@@ -91,7 +91,7 @@ With same objects than above, just by adding validation groups:
 
 ```js
   constraint = {
-    name:      [ new Assert().NotBlank(), new Assert( 'edit' ).Length( { min: 4, max: 25 } ) ],
+    name:      [ new Assert().NotBlank(), new Assert( 'edit' ).Range( 4, 25 ) ],
     email:     new Assert().Email(),
     firstname: new Assert( [ 'edit', 'register'] ).NotBlank(),
     phone:     new Assert( 'edit' ).NotBlank()
@@ -124,7 +124,7 @@ Validator.js (see below), but you can implement yours for your needs using the
 `Callback()` assert (see below).
 
 ```js
-var length = new Validator.Assert().Length( { min: 10 } );
+var length = new Validator.Assert().Range( 10, Number.MAX_VALUE );
 try {
   length.check( 'foo' );
 } catch ( violation ) {}
@@ -135,7 +135,7 @@ try {
 A Constraint is a set of asserts nodes that would be used to validate an object.
 
 ```js
-var length = new Validator.Assert().Length( { min: 10 } );
+var length = new Validator.Assert().Range( 10, Number.MAX_VALUE );
 var notBlank = new Validator.Assert().NotBlank();
 var constraint = new Constraint( { foo: length, bar: notBlank } );
 
@@ -184,7 +184,7 @@ new Assert().GreaterThan( threshold );
 new Assert().GreaterThanOrEqual( threshold );
 new Assert().InstanceOf( classRef );
 new Assert().IsString();
-new Assert().Length( { min: value, max: value } );
+new Assert().Length( value );
 new Assert().HaveProperty( propertyName );
 new Assert().LessThan( threshold );
 new Assert().LessThanOrEqual( threshold );
@@ -273,12 +273,12 @@ it( 'Callback', function () {
 ```
 
 ### A note on type checking
-Note that `Length` assertion works for both String and Array type, so if you want to validate only strings, you should write an additional assertion:
+Note that `Range` assertion works for both String and Array type, so if you want to validate only strings, you should write an additional assertion:
 ```js
 var Assert = Validator.Assert;
 
 Validator.Validator().validate( 'foo', [
-  new Assert().Length( { min: 4, max: 100 } ),
+  new Assert().Range( 4, 100 ),
   new Assert().IsString()
 ] );
 ```

--- a/src/validator.js
+++ b/src/validator.js
@@ -641,27 +641,20 @@
       return this;
     },
 
-    Length: function ( boundaries ) {
+    Length: function ( length ) {
       this.__class__ = 'Length';
 
-      if ( !boundaries.min && !boundaries.max )
-        throw new Error( 'Lenth assert must be instanciated with a { min: x, max: y } object' );
+      if ( 'undefined' === typeof length )
+        throw new Error( 'Should give a length value' );
 
-      this.min = boundaries.min;
-      this.max = boundaries.max;
+      this.length = length;
 
       this.validate = function ( value ) {
         if ( 'string' !== typeof value && !_isArray( value ) )
           throw new Violation( this, value, { value: Validator.errorCode.must_be_a_string_or_array } );
 
-        if ( 'undefined' !== typeof this.min && this.min === this.max && value.length !== this.min )
-          throw new Violation( this, value, { min: this.min, max: this.max } );
-
-        if ( 'undefined' !== typeof this.max && value.length > this.max )
-          throw new Violation( this, value, { max: this.max } );
-
-        if ( 'undefined' !== typeof this.min && value.length < this.min )
-          throw new Violation( this, value, { min: this.min } );
+        if ( value.length != this.length )
+          throw new Violation( this, value, { length: this.length } );
 
         return true;
       };
@@ -766,7 +759,7 @@
           try {
             // validate strings and objects with their Length
             if ( ( 'string' === typeof value && isNaN( Number( value ) ) ) || _isArray( value ) )
-              new Assert().Length( { min: this.min, max: this.max } ).validate( value );
+              new Assert().GreaterThanOrEqual( this.min ).validate( value.length ) && new Assert().LessThanOrEqual( this.max ).validate( value.length );
 
             // validate numbers with their value
             else
@@ -816,7 +809,7 @@
           if ( 'string' === typeof value )
             new Assert().NotNull().validate( value ) && new Assert().NotBlank().validate( value );
           else if ( true === _isArray( value ) )
-            new Assert().Length( { min: 1 } ).validate( value );
+            new Assert().Range( 1, Number.MAX_VALUE ).validate( value );
         } catch ( violation ) {
           throw new Violation( this, value );
         }

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -23,19 +23,19 @@ var Suite = function ( Validator, expect, extras ) {
       } )
 
       it( 'should instanciate an assertion', function () {
-        var Length = new Assert().Length( { min: 10 } );
+        var Length = new Assert().Length( 10 );
         expect( Length ).to.be.an( 'object' );
         expect( Length.__class__ ).to.be( 'Length' );
         expect( assert.__parentClass__ ).to.be( 'Assert' );
       } )
 
       it( 'should return true if validate success', function () {
-        var Length = new Assert().Length( { min: 10 } );
+        var Length = new Assert().Length( 11 );
         expect( Length.validate( 'foo bar baz' ) ).to.be( true );
       } )
 
       it( 'should throw a Violation exception if fails', function () {
-        var Length = new Assert().Length( { min: 10 } );
+        var Length = new Assert().Length( 10 );
         try {
           Length.validate( 'foo' );
           expect().fails();
@@ -45,54 +45,54 @@ var Suite = function ( Validator, expect, extras ) {
       } )
 
       it( 'should register a group through assertion construct ', function () {
-        var Length = new Assert( 'foo' ).Length( { min: 10, min: 15 } );
-        expect( Length.hasGroups() ).to.be( true );
-        expect( Length.hasGroup( 'foo' ) ).to.be( true );
+        var Range = new Assert( 'foo' ).Range( 10, 15 );
+        expect( Range.hasGroups() ).to.be( true );
+        expect( Range.hasGroup( 'foo' ) ).to.be( true );
       } )
 
       it( 'should register mulitple groups through assertion construct', function () {
-        var Length = new Assert( [ 'foo', 'bar'] ).Length( { min: 10, min: 15 } );
-        expect( Length.hasGroups() ).to.be( true );
-        expect( Length.hasGroup( 'foo' ) ).to.be( true );
-        expect( Length.hasGroup( 'bar' ) ).to.be( true );
+        var Range = new Assert( [ 'foo', 'bar'] ).Range( 10, 15 );
+        expect( Range.hasGroups() ).to.be( true );
+        expect( Range.hasGroup( 'foo' ) ).to.be( true );
+        expect( Range.hasGroup( 'bar' ) ).to.be( true );
       } )
 
       it( 'should register a group through addGroup ', function () {
-        var Length = new Assert().Length( { min: 10 } ).addGroup( 'foo' );
+        var Length = new Assert().Length( 10 ).addGroup( 'foo' );
         expect( Length.hasGroups() ).to.be( true );
         expect( Length.hasGroup( 'foo' ) ).to.be( true );
       } )
 
       it( 'should register multiple groups through addGroup', function () {
-        var Length = new Assert().Length( { min: 10 } ).addGroup( [ 'foo', 'bar' ] );
+        var Length = new Assert().Length( 10 ).addGroup( [ 'foo', 'bar' ] );
         expect( Length.hasGroups() ).to.be( true );
         expect( Length.hasGroup( 'foo' ) ).to.be( true );
         expect( Length.hasGroup( 'bar' ) ).to.be( true );
       } )
 
       it( 'should register mulitple groups through addGroups', function () {
-        var Length = new Assert().Length( { min: 10 } ).addGroups( [ 'foo', 'bar'] );
+        var Length = new Assert().Length( 10 ).addGroups( [ 'foo', 'bar'] );
         expect( Length.hasGroups() ).to.be( true );
         expect( Length.hasGroup( 'foo' ) ).to.be( true );
         expect( Length.hasGroup( 'bar' ) ).to.be( true );
       } )
 
       it( 'should register mulitple groups through chained addGroup', function () {
-        var Length = new Assert().Length( { min: 10 } ).addGroup( 'foo' ).addGroup( 'bar' );
+        var Length = new Assert().Length( 10 ).addGroup( 'foo' ).addGroup( 'bar' );
         expect( Length.hasGroups() ).to.be( true );
         expect( Length.hasGroup( 'foo' ) ).to.be( true );
         expect( Length.hasGroup( 'bar' ) ).to.be( true );
       } )
 
       it( 'should remove group', function () {
-        var Length = new Assert().Length( { min: 10 } ).addGroup( 'foo' ).addGroup( 'bar' ).removeGroup( 'bar' );
+        var Length = new Assert().Length( 10 ).addGroup( 'foo' ).addGroup( 'bar' ).removeGroup( 'bar' );
         expect( Length.hasGroups() ).to.be( true );
         expect( Length.hasGroup( 'foo' ) ).to.be( true );
         expect( Length.hasGroup( 'bar' ) ).to.be( false );
       } )
 
       it( 'should test hasOneOf for groups', function () {
-        var Length = new Assert().Length( { min: 10 } ).addGroup( [ 'foo', 'bar' ] );
+        var Length = new Assert().Length( 10 ).addGroup( [ 'foo', 'bar' ] );
         expect( Length.hasOneOf( [ 'foo', 'baz' ] ) ).to.be( true );
         expect( Length.hasOneOf( [ 'bar', 'baz' ] ) ).to.be( true );
         expect( Length.hasOneOf( [ 'foobar', 'baz', 'foobaz' ] ) ).to.be( false );
@@ -180,27 +180,49 @@ var Suite = function ( Validator, expect, extras ) {
       } )
 
       it( 'Length', function () {
-        assert = new Assert().Length( { min: 3 } );
+        assert = new Assert().Length( 3 );
 
         expect( validate( null, assert ) ).not.to.be( true );
         expect( validate( '', assert ) ).not.to.be( true );
         expect( validate( false, assert ) ).not.to.be( true );
         expect( validate( false, assert ).show() ).to.eql( { assert: 'Length', value: false, violation: { value: 'must_be_a_string_or_array' } } );
         expect( validate( 'foo', assert ) ).to.be( true );
-        expect( validate( 'f', assert ).show() ).to.eql( { assert: 'Length', value: 'f', violation: { min: 3 } } );
+        expect( validate( 'f', assert ).show() ).to.eql( { assert: 'Length', value: 'f', violation: { length: 3 } } );
         expect( validate( 'f', assert ) ).not.to.be( true );
 
-        assert = new Assert().Length( { max: 10 } );
+        assert = new Assert().Length( 10 );
         expect( validate( 'foo bar baz', assert ) ).not.to.be( true );
-        expect( validate( 'foo bar baz', assert ).show() ).to.eql( { assert: 'Length', value: 'foo bar baz', violation: { max: 10 } } );
-      } )
+        expect( validate( 'foo bar baz', assert ).show() ).to.eql( { assert: 'Length', value: 'foo bar baz', violation: { length: 10 } } );
+      })
 
       it( 'Length for arrays', function () {
-        assert = new Assert().Length( { min: 3, max: 5 } );
-        expect( validator.validate([], assert) ).not.to.be( true );
-        expect( validator.validate(['foo'], assert) ).not.to.be( true );
-        expect( validator.validate(['foo', 'bar', 'baz'], assert) ).to.be( true );
-        expect( validator.validate(['foo', 'bar', 'baz', 'qux', 'bux', 'pux'], assert) ).not.to.be( true );
+        assert = new Assert().Length( 3 );
+        expect( validator.validate( [], assert ) ).not.to.be( true );
+        expect( validator.validate( ['foo'], assert ) ).not.to.be( true );
+        expect( validator.validate( ['foo', 'bar', 'baz'], assert ) ).to.be( true );
+        expect( validator.validate( ['foo', 'bar', 'baz', 'qux', 'bux', 'pux'], assert ) ).not.to.be( true );
+      } )
+
+      it( 'Length Range for strings', function () {
+        assert = new Assert().Range( 3, Number.MAX_VALUE );
+
+        expect( validate( null, assert ) ).not.to.be( true );
+        expect( validate( '', assert ) ).not.to.be( true );
+        expect( validate( false, assert ) ).not.to.be( true );
+
+        expect( validate( 'foo', assert ) ).to.be( true );
+        expect( validate( 'f', assert ) ).not.to.be( true );
+
+        assert = new Assert().Range( 0, 10 );
+        expect( validate( 'foo bar baz', assert ) ).not.to.be( true );
+      } )
+
+      it( 'Length Range for arrays', function () {
+        assert = new Assert().Range( 3, 5 );
+        expect( validator.validate( [], assert) ).not.to.be( true );
+        expect( validator.validate( ['foo'], assert) ).not.to.be( true );
+        expect( validator.validate( ['foo', 'bar', 'baz'], assert ) ).to.be( true );
+        expect( validator.validate( ['foo', 'bar', 'baz', 'qux', 'bux', 'pux'], assert ) ).not.to.be( true );
       } )
 
       it( 'Email', function () {
@@ -459,10 +481,8 @@ var Suite = function ( Validator, expect, extras ) {
 
         // with strings
         expect( validate( 'foo', assert ) ).not.to.be( true );
-        expect( validate( 'foo', assert ).show() ).to.eql( { assert: 'Range', value: 'foo', violation: { min: 5 } } );
         expect( validate( 'foo bar', assert ) ).to.be( true );
         expect( validate( 'foo bar baz', assert ) ).not.to.be( true );
-        expect( validate( 'foo bar baz', assert ).show() ).to.eql( { assert: 'Range', value: 'foo bar baz', violation: { max: 10 } } );
 
         // with arrays
         expect( validate( ['foo'], assert ) ).not.to.be( true );
@@ -577,7 +597,7 @@ var Suite = function ( Validator, expect, extras ) {
 
       it( 'should throw an error if not instanciated with an object', function () {
         try {
-          new Constraint( new Assert().Length( { min: 10 } ) );
+          new Constraint( new Assert().Length( 10 ) );
           expect().fails();
         } catch ( err ) {
           expect( err.message ).to.be( 'Should give a valid mapping object to Constraint' );
@@ -585,19 +605,19 @@ var Suite = function ( Validator, expect, extras ) {
       } )
 
       it( 'should be instanciated with a simple object', function () {
-        var myConstraint = new Constraint( { foo: new Assert().Length( { min: 10 } ) } );
+        var myConstraint = new Constraint( { foo: new Assert().Length( 10 ) } );
         expect( myConstraint.has( 'foo' ) ).to.be( true );
       } )
 
       it( 'should add a node: Assert', function () {
         var myConstraint = new Constraint();
-        myConstraint.add( 'foo', new Assert().Length( { min: 10 } ) );
+        myConstraint.add( 'foo', new Assert().Length( 10 ) );
         expect( myConstraint.has( 'foo' ) ).to.be( true );
       } )
 
       it( 'should add a node: Constraint', function () {
         var myConstraint = new Constraint();
-        myConstraint.add( 'foo', new Constraint( { bar: new Assert().Length( { min: 10 } ) } ) );
+        myConstraint.add( 'foo', new Constraint( { bar: new Assert().Length( 10 ) } ) );
         expect( myConstraint.has( 'foo' ) ).to.be( true );
         expect( myConstraint.get( 'foo' ).has( 'bar' ) ).to.be( true );
       } )
@@ -657,7 +677,7 @@ var Suite = function ( Validator, expect, extras ) {
       } )
 
       describe( 'String validation', function () {
-        it( 'sould throw Error if not trying to validate a string against Assert or Asserts array', function () {
+        it( 'should throw Error if not trying to validate a string against Assert or Asserts array', function () {
           try {
             validator.validate( 'foo', 'bar' );
             expect().fail();
@@ -667,24 +687,24 @@ var Suite = function ( Validator, expect, extras ) {
         } )
 
         it( 'should validate a string', function () {
-          expect( validator.validate( 'foo', [ new Assert().Length( { min: 5, max: 10 } ), new Assert().NotBlank() ] ) ).not.to.be( true );
-          expect( validator.validate( 'foobar', [ new Assert().Length( { min: 5, max: 10 } ), new Assert().NotBlank() ] ) ).to.be( true );
+          expect( validator.validate( 'foo', [ new Assert().Range( 5, 10 ), new Assert().NotBlank() ] ) ).not.to.be( true );
+          expect( validator.validate( 'foobar', [ new Assert().Range( 5, 10 ), new Assert().NotBlank() ] ) ).to.be( true );
         } )
 
         it( 'should return violations for a string', function () {
-          var asserts = [ new Assert().Length( { min: 5, max: 10 } ), new Assert().NotBlank() ];
+          var asserts = [ new Assert().Range( 5, 10 ), new Assert().NotBlank() ];
           var violations = validator.validate( '', asserts );
           expect( violations ).to.have.length( 2 );
           expect( violations[ 0 ] ).to.be.a( Validator.Violation );
-          expect( violations[ 0 ].assert.__class__ ).to.be( 'Length' );
+          expect( violations[ 0 ].assert.__class__ ).to.be( 'Range' );
           expect( violations[ 1 ].assert.__class__ ).to.be( 'NotBlank' );
           violations = validator.validate( 'foo', asserts );
           expect( violations ).to.have.length( 1 );
-          expect( violations[ 0 ].assert.__class__).to.be( 'Length' );
+          expect( violations[ 0 ].assert.__class__).to.be( 'Range' );
         } )
 
         it( 'should use groups for validation', function() {
-          var asserts = [ new Assert().Length( { min: 4 } ).addGroup( 'bar' ), new Assert().Length( { min: 8 } ).addGroup( 'baz' ), new Assert().Length( { min: 2 } ) ];
+          var asserts = [ new Assert().Range( 4, Number.MAX_VALUE ).addGroup( 'bar' ), new Assert().Range( 8, Number.MAX_VALUE ).addGroup( 'baz' ), new Assert().Range( 2, Number.MAX_VALUE ) ];
           expect( validator.validate( 'foo', asserts ) ).to.be( true );
           expect( validator.validate( 'foo', asserts, 'bar' ) ).not.to.be( true );
           expect( validator.validate( 'foofoo', asserts, 'bar' ) ).to.be( true );
@@ -693,7 +713,7 @@ var Suite = function ( Validator, expect, extras ) {
         } )
 
         it( 'should use numbers as groups for validation', function () {
-          var asserts = [ new Assert().Length( { min: 4 } ).addGroup( 512 ), new Assert().Length( { min: 8 } ).addGroup( 1024 ), new Assert().Length( { min: 2 } ) ];
+          var asserts = [ new Assert().Range( 4, Number.MAX_VALUE ).addGroup( 512 ), new Assert().Range( 8, Number.MAX_VALUE ).addGroup( 1024 ), new Assert().Range( 2, Number.MAX_VALUE ) ];
           expect( validator.validate( 'foo', asserts ) ).to.be( true );
           expect( validator.validate( 'foo', asserts, 512 ) ).not.to.be( true );
           expect( validator.validate( 'foofoo', asserts, 512 ) ).to.be( true );
@@ -735,7 +755,7 @@ var Suite = function ( Validator, expect, extras ) {
         it( 'should validate required properties', function () {
           var constraint = {
             foo: new Assert().Required(),
-            bar: [ new Assert().Required(), new Assert().Length( { min: 4 } ) ],
+            bar: [ new Assert().Required(), new Assert().Length( 4 ) ],
           };
 
           var result = validator.validate( {
@@ -755,7 +775,7 @@ var Suite = function ( Validator, expect, extras ) {
           expect( result ).not.to.be( true );
           expect( result.bar[0] ).to.be.a( Violation );
           expect( result.bar[0].assert.__class__ ).to.be( 'Length' );
-          expect( result.bar[0].violation ).to.eql( { min: 4 } );
+          expect( result.bar[0].violation ).to.eql( { length: 4 } );
 
           var result = validator.validate( {
             foo: 'foo',
@@ -812,7 +832,7 @@ var Suite = function ( Validator, expect, extras ) {
 
         it( 'should validate an object with a complex constraint', function () {
           var constraint = new Constraint()
-              .add( 'name', new Assert().Length( { min: 5, max: 15 } ) )
+              .add( 'name', new Assert().Range( 5, 15 ) )
               .add( 'email', new Assert().NotBlank() );
 
           var result = validator.validate( { name: 'foo', email: '' }, constraint );
@@ -823,7 +843,7 @@ var Suite = function ( Validator, expect, extras ) {
 
           expect( result.name[ 0 ] ).to.be.a( Violation );
           expect( result.email[ 0 ] ).to.be.a( Violation );
-          expect( result.name[ 0 ].assert.__class__ ).to.be( 'Length' );
+          expect( result.name[ 0 ].assert.__class__ ).to.be( 'Range' );
           expect( result.email[ 0 ].assert.__class__ ).to.be( 'NotBlank' );
 
           result = validator.validate( { name: 'foo bar', email: '' }, constraint );
@@ -837,7 +857,7 @@ var Suite = function ( Validator, expect, extras ) {
 
         it( 'should validate an object against a validation object', function () {
           var result = validator.validate( { name: 'foo', email: '' }, {
-            name: new Assert().Length( { min: 5 } ),
+            name: new Assert().Length( 5 ),
             email: new Assert().NotBlank()
           } );
 
@@ -853,7 +873,7 @@ var Suite = function ( Validator, expect, extras ) {
               phone: null
             },
             constraint = new Constraint({
-              name:      [ new Assert().NotBlank(), new Assert().Length( { min: 4, max: 25 } ) ],
+              name:      [ new Assert().NotBlank(), new Assert().Range( 4, 25 ) ],
               email:     new Assert().Email(),
               firstname: new Assert().NotBlank().addGroup( ['foo', 'register'] ),
               phone:     new Assert().NotBlank().addGroup( 'edit' )


### PR DESCRIPTION
* Renamed `Length` validator to `LengthRange`, parameters unchanged

* Created new `Length` validator, accepts integer to match length against