### PR TITLE
Fix nested strict validation

### DIFF
--- a/src/validator.js
+++ b/src/validator.js
@@ -183,7 +183,7 @@
       }
 
       if ( 'object' === typeof object && !_isArray( object ) ) {
-        this.nodes[ node ] = object instanceof Constraint ? object : new Constraint( object );
+        this.nodes[ node ] = object instanceof Constraint ? object : new Constraint( object, this.options );
 
         return this;
       }

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -895,6 +895,25 @@ var Suite = function ( Validator, expect, extras ) {
           expect( result.bar.violation.value ).to.be( 'bar' );
         } )
 
+        it( 'should validate nested required properties in strict mode', function () {
+          var constraint = new Constraint( {
+            foo: {
+              bar: {
+                biz: new Assert().Required()
+              }
+            }
+          }, { strict: true } );
+
+          var result = validator.validate( {
+            foo: {}
+          }, constraint );
+
+          expect( result ).not.to.be( true );
+          expect( result.foo.bar ).to.be.a( Violation );
+          expect( result.foo.bar.assert.__class__ ).to.be( 'HaveProperty' );
+          expect( result.foo.bar.violation.value ).to.be( 'bar' );
+        } )
+
         it( 'should use default or strict validation', function () {
           var constraint = {
             foo: new Assert().Required(),


### PR DESCRIPTION
This PR passes the options object to nested constraints so that they may inherit the `strict` property.

Take, for example, the following constraints:

```js
{
  user: {
    name: {
      first: new Assert().Required(),
      last: new Assert().Required()
    }
  }
}
```

If you try to validate with the object: `{ user: {} }`, this will return `true`, even in `strict` mode, which is not desired. 

This fix allows the nested `name` object to receive the `strict` mode validation from its parent.