### PR TITLE
Add deep required option

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,9 @@ constraint.check(object);
 ```
 will return a `HaveProperty` Violation, saying that `foo` property does not exist.
 
+This option also works when `Collection` is used, but doesn't enforce a non empty array
+on the validated object.
+
 ## Available asserts
 
 ```js

--- a/README.md
+++ b/README.md
@@ -166,6 +166,25 @@ constraint.check( object );
 will return a `HaveProperty` Violation, saying that `baz` property does not exist
 in validated object. Without `{ strict: true }` this check would return `true`.
 
+### Deep required validation
+
+By default, a `Required` constraint fails if the parent property exists in the validated
+object and the property doesn't. To force Validator.js to take into account all `Required`
+constraints, no matter the validated object, you have to enable the `deepRequired` option:
+
+```js
+var object = { };
+
+var constraint = new Constraint({
+  foo: {
+    bar: new Assert().Required()
+  }
+}, { deepRequired: true });
+
+constraint.check(object);
+```
+will return a `HaveProperty` Violation, saying that `foo` property does not exist.
+
 ## Available asserts
 
 ```js

--- a/src/validator.js
+++ b/src/validator.js
@@ -134,7 +134,7 @@
 
     constructor: Constraint,
 
-    isRequired: function ( property, group ) {
+    isRequired: function( property, group, deepRequired ) {
       var constraint = this.get( property );
       var constraints = _isArray( constraint ) ? constraint : [constraint];
 
@@ -147,10 +147,19 @@
           }
         }
 
-        if ( constraint instanceof Constraint && this.options.deepRequired ) {
-          for ( var node in constraint.nodes ) {
-            if ( constraint.isRequired( node, group ) ) {
-              return true;
+        if ( deepRequired ) {
+          if ( 'Collection' === constraint.__class__ ) {
+            constraint = constraint.constraint;
+
+            // ensure constraint of collection gets the same deepRequired option
+            constraint.options.deepRequired = deepRequired;
+          }
+
+          if ( constraint instanceof Constraint ) {
+            for ( var node in constraint.nodes ) {
+              if ( constraint.isRequired( node, group, deepRequired ) ) {
+                return true;
+              }
             }
           }
         }
@@ -164,7 +173,7 @@
 
       // check all constraint nodes.
       for ( var property in this.nodes ) {
-        var isRequired = this.isRequired( property, group );
+        var isRequired = this.isRequired( property, group, this.options.deepRequired );
 
         if ( ! this.has( property, object ) && ! this.options.strict && ! isRequired ) {
           continue;
@@ -191,7 +200,7 @@
     },
 
     add: function ( node, object ) {
-      if ( object instanceof Assert  || ( _isArray( object ) && object[ 0 ] instanceof Assert ) ) {
+      if ( object instanceof Assert || ( _isArray( object ) && object[ 0 ] instanceof Assert ) ) {
         this.nodes[ node ] = object;
 
         return this;

--- a/src/validator.js
+++ b/src/validator.js
@@ -134,22 +134,37 @@
 
     constructor: Constraint,
 
+    isRequired: function ( property, group ) {
+      var constraint = this.get( property );
+      var constraints = _isArray( constraint ) ? constraint : [constraint];
+
+      for ( var i = constraints.length - 1; i >= 0; i-- ) {
+        constraint = constraints[i];
+
+        if ( 'Required' === constraint.__class__ ) {
+          if ( constraints[i].requiresValidation( group ) ) {
+            return true;
+          }
+        }
+
+        if ( constraint instanceof Constraint && this.options.deepRequired ) {
+          for ( var node in constraint.nodes ) {
+            if ( constraint.isRequired( node, group ) ) {
+              return true;
+            }
+          }
+        }
+      }
+
+      return false;
+    },
+
     check: function ( object, group ) {
       var result, failures = {};
 
       // check all constraint nodes.
       for ( var property in this.nodes ) {
-        var isRequired = false;
-        var constraint = this.get(property);
-        var constraints = _isArray( constraint ) ? constraint : [constraint];
-
-        for (var i = constraints.length - 1; i >= 0; i--) {
-          if ( 'Required' === constraints[i].__class__ ) {
-            isRequired = constraints[i].requiresValidation( group );
-
-            continue;
-          }
-        }
+        var isRequired = this.isRequired( property, group );
 
         if ( ! this.has( property, object ) && ! this.options.strict && ! isRequired ) {
           continue;

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -879,6 +879,21 @@ var Suite = function ( Validator, expect, extras ) {
           expect( result ).to.be( true );
         } )
 
+        it( 'should validate required properties in deepRequired mode', function () {
+          var constraint = new Constraint({
+            foo: {
+              bar: new Assert().Required()
+            }
+          }, { deepRequired: true });
+
+          var result = validator.validate( { }, constraint );
+
+          expect( result ).not.to.be( true );
+          expect( result.foo ).to.be.a( Violation );
+          expect( result.foo.assert.__class__ ).to.be( 'HaveProperty' );
+          expect( result.foo.violation.value ).to.be( 'foo' );
+        } )
+
         it( 'should validate required properties in strict mode', function () {
           var constraint = new Constraint( {
             foo: new Assert().Required(),

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -824,6 +824,8 @@ var Suite = function ( Validator, expect, extras ) {
           expect( validator.validate( ['foo@bar.baz', 'not an email'], assert ) ).not.to.be( true );
           expect( validator.validate( ['foo@bar.baz', 'not an email'], assert )[ 0 ][ '1' ][ 0 ].__class__ ).to.be( 'Violation' );
         } )
+
+
       } )
 
       describe( 'Object validation', function () {
@@ -892,6 +894,34 @@ var Suite = function ( Validator, expect, extras ) {
           expect( result.foo ).to.be.a( Violation );
           expect( result.foo.assert.__class__ ).to.be( 'HaveProperty' );
           expect( result.foo.violation.value ).to.be( 'foo' );
+        } )
+
+        it( 'should validate empty array in deepRequired mode', function () {
+          var constraint = new Constraint({
+            foo: new Assert().Collection({
+              bar: new Assert().Required()
+            })
+          }, { deepRequired: true });
+
+          var result = validator.validate( { foo: [ ] }, constraint );
+
+          expect( result ).to.be( true );
+        } )
+
+        it( 'should validate array of objects in deepRequired mode', function () {
+          var constraint = new Constraint({
+            foo: new Assert().Collection({
+              bar: new Assert().Required()
+            })
+          }, { deepRequired: true });
+
+          var result = validator.validate( { foo: [ { } ] }, constraint );
+
+          expect( result ).not.to.be( true );
+          expect( result.foo ).to.be.an( Array );
+          expect( result.foo[0]['0'].bar ).to.be.a( Violation );
+          expect( result.foo[0]['0'].bar.assert.__class__ ).to.be( 'HaveProperty' );
+          expect( result.foo[0]['0'].bar.value ).to.eql( { } );
         } )
 
         it( 'should validate required properties in strict mode', function () {


### PR DESCRIPTION
Enabling this option causes the `Constraint` to fail if it has at least one `Required` assert, no matter the validated data.

In the following example, the validation will fail because `bar` node is required even if `foo` is not.
 
```js
var constraint = new Constraint({
  foo: {
    bar: new Assert().Required()
  }
}, { deepRequired: true });

var result = validator.validate( { }, constraint );
```

Depends on #39 