### PR TITLE
Fix exception when validating an object Collection

### DIFF
--- a/src/validator.js
+++ b/src/validator.js
@@ -94,6 +94,9 @@
       if ( 'object' !== typeof constraint )
         throw new Error( 'You must give a constraint to validate an object' );
 
+      if ( constraint instanceof Assert )
+        return constraint.check( object, group );
+
       if ( constraint instanceof Constraint )
         return constraint.check( object, group );
 

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -477,11 +477,13 @@ var Suite = function ( Validator, expect, extras ) {
               'foo',
               'bar@qux.com',
               'baz'
-            ]
+            ],
+            strings: [ {} ]
           },
           constraint = {
             foo: new Assert().NotNull(),
-            items: [ new Assert().Collection( new Assert().Email() ), new Assert().Count( 2 ) ]
+            items: [ new Assert().Collection( new Assert().Email() ), new Assert().Count( 2 ) ],
+            strings: [ new Assert().Collection( new Assert().IsString() ) ]
           };
 
         var result = validator.validate( object, constraint );
@@ -497,6 +499,9 @@ var Suite = function ( Validator, expect, extras ) {
         expect( result.items[ 0 ][ 2 ][ 0 ].assert.__class__ ).to.be( 'Email' );
         expect( result.items[ 1 ] ).to.be.a( Violation );
         expect( result.items[ 1 ].assert.__class__ ).to.be( 'Count' );
+        expect( result.strings[ 0 ] ).to.have.key( '0' );
+        expect( result.strings[ 0 ][ 0 ] ).to.be.a( Violation );
+        expect( result.strings[ 0 ][ 0 ].assert.__class__ ).to.be( 'IsString' );
       } )
 
       it( 'Collection with binded objects', function () {


### PR DESCRIPTION
Fixes an error when validating an object (`{}`) with a Collection assert.

For example. These validations all worked:

```js
validate({
  foo: 'foobar',
  bar: 123,
  biz: ['what']
}, {
  foo: new Assert().Collection(new Assert().Email()),
  bar: new Assert().Collection(new Assert().Email()),
  biz: new Assert().Collection(new Assert().Email())
})
```

But this one crashed:
```js
validate({
  foo: {}
}, {
  foo: new Assert().Collection(new Assert().Email())
})

// Error: Should give a valid mapping object to Constraint
```

This is because, in the *[validate](https://github.com/guillaumepotier/validator.js/blob/master/src/validator.js#L32-L45)* function, the `_validateObject()` method will be called and will assume that a constraint was passed, instead of an Assert.