### PR TITLE
Add validation messages

### DIFF
--- a/src/validator.js
+++ b/src/validator.js
@@ -137,7 +137,11 @@
 
     constructor: Constraint,
 
-    isRequired: function( property, group, deepRequired ) {
+    isRequired: function( property, group, deepRequired ){
+      return this.getContraintIfRequired( property, group, deepRequired ) !== undefined;
+    },
+
+    getContraintIfRequired: function( property, group, deepRequired ) {
       var constraint = this.get( property );
       var constraints = _isArray( constraint ) ? constraint : [constraint];
 
@@ -160,7 +164,7 @@
             constraint.options.deepRequired = deepRequired;
 
             for ( var node in constraint.nodes ) {
-              if ( constraint.isRequired( node, group, deepRequired ) ) {
+              if ( constraint.getContraintIfRequired( node, group, deepRequired ) ) {
                 return constraint;
               }
             }
@@ -175,7 +179,7 @@
 
       // check all constraint nodes.
       for ( var property in this.nodes ) {
-        var contraint = this.isRequired( property, group, this.options.deepRequired );
+        var contraint = this.getContraintIfRequired( property, group, this.options.deepRequired );
 
         if ( ! this.has( property, object ) && ! this.options.strict && (contraint === undefined) ) {
           continue;
@@ -489,7 +493,7 @@
       return this;
     },
 
-    Blank: function () {
+    Blank: function ( message ) {
       this.__class__ = 'Blank';
       message = message || 'This field should be blank';
 
@@ -506,7 +510,7 @@
       return this;
     },
 
-    Callback: function ( fn ) {
+    Callback: function ( fn, message ) {
       this.__class__ = 'Callback';
       this.arguments = Array.prototype.slice.call( arguments );
       message = message || 'This field didn \'t pass callback';
@@ -541,10 +545,11 @@
 
     Choice: function ( list, message ) {
       this.__class__ = 'Choice';
-      message = message || 'This field must be any of: ' + list.join(', ');
 
       if ( !_isArray( list ) && 'function' !== typeof list )
         throw new Error( 'Choice must be instanciated with an array or a function' );
+      
+      message = message || 'This field is not in the allowed choices.';
 
       this.list = list;
 
@@ -868,7 +873,7 @@
       return this;
     },
 
-    Range: function ( min, max ) {
+    Range: function ( min, max, message ) {
       this.__class__ = 'Range';
       message = message || 'This field must be in range between ' + min + ' and ' + max;
 

--- a/src/validator.js
+++ b/src/validator.js
@@ -208,10 +208,35 @@
     getErrorMessages: function( violations ){
 
       var messages = {};
-      for(violation in violations){
-        messages[violation] = violations[violation].map(function(violation){
-          return violation.message;
-        });
+      for(var field in violations){
+      
+        if(_isArray(violations[field])){
+          
+          var fieldMessages = [];
+          
+          violations[field].map(function(violation, index, array){
+
+            if(violation instanceof Violation){
+              //Simple violation 
+              fieldMessages[index] = violation.message;
+            }else{
+              //Collection
+              for(var i in violation){
+                var subViolation = violation[i];
+                fieldMessages[i] = this.getErrorMessages(subViolation);
+              }
+              
+            }
+
+          }.bind(this));
+
+          messages[field] = fieldMessages;
+
+        }else{
+          //Nested Object
+
+        }
+
       }
 
       return messages;
@@ -548,7 +573,7 @@
 
       if ( !_isArray( list ) && 'function' !== typeof list )
         throw new Error( 'Choice must be instanciated with an array or a function' );
-      
+
       message = message || 'This field is not in the allowed choices.';
 
       this.list = list;

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -1,4 +1,3 @@
-
 var sinon = require('sinon');
 
 ( function ( exports ) {
@@ -937,7 +936,7 @@ var Suite = function ( Validator, expect, extras ) {
 
           expect( result ).not.to.be( true );
           expect( result.foo ).to.be.an( Array );
-          expect( result.foo[0]['0'].bar ).to.be.a( Violation );
+          expect( result.foo[0]['0'].bar ).to.be.a( Assert.Required );
           expect( result.foo[0]['0'].bar.assert.__class__ ).to.be( 'HaveProperty' );
           expect( result.foo[0]['0'].bar.value ).to.eql( { } );
         } )
@@ -1258,6 +1257,56 @@ var Suite = function ( Validator, expect, extras ) {
           expect( result.items[ 0 ][ 0 ] ).not.to.have.key( 'biz' );
         } )
       } )
+    
+      describe( 'Error Messages', function() {
+
+        it( 'should give simple error message', function() {
+          
+          var object = { foo: null, bar: null, baz: null, qux: null };
+          var constraint = new Constraint({
+            foo: [ new Assert().NotBlank('This field is required') ],
+          });
+
+          var result = constraint.getErrorMessages( constraint.check( object ) );
+
+          expect( result ).to.have.key( 'foo' );
+          expect( result ).to.eql( {
+            foo: [ 'This field is required' ]
+          } );
+
+        } )
+
+        it( 'should give error for missing property', function() {
+
+          var object = { baz: 'a' };
+          var constraint = new Constraint({
+            foo: [ new Assert().Required('This field is required') ],
+            bar: [ new Assert().Required('This field is required') ],
+            baz: [ new Assert().Required('This field is required') ]
+          });
+
+          var result = constraint.getErrorMessages( constraint.check( object ) );
+
+          expect( result ).to.have.key( 'foo' );
+          expect( result ).to.have.key( 'bar' );
+          expect( result ).not.to.have.key( 'baz' );
+          expect( result ).to.eql( {
+            foo: [ 'This field is required' ],
+            bar: [ 'This field is required' ],
+          } );
+
+        } )
+
+        it( 'should give a message for a collection', function() {
+
+        } )
+
+        it( 'should give error for nested objects', function() {
+
+        } )
+
+      } )
+
     } )
   } )
 }

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -1,3 +1,4 @@
+
 var sinon = require('sinon');
 
 ( function ( exports ) {
@@ -936,7 +937,7 @@ var Suite = function ( Validator, expect, extras ) {
 
           expect( result ).not.to.be( true );
           expect( result.foo ).to.be.an( Array );
-          expect( result.foo[0]['0'].bar ).to.be.a( Assert.Required );
+          expect( result.foo[0]['0'].bar ).to.be.a( Violation );
           expect( result.foo[0]['0'].bar.assert.__class__ ).to.be( 'HaveProperty' );
           expect( result.foo[0]['0'].bar.value ).to.eql( { } );
         } )
@@ -1257,56 +1258,6 @@ var Suite = function ( Validator, expect, extras ) {
           expect( result.items[ 0 ][ 0 ] ).not.to.have.key( 'biz' );
         } )
       } )
-    
-      describe( 'Error Messages', function() {
-
-        it( 'should give simple error message', function() {
-          
-          var object = { foo: null, bar: null, baz: null, qux: null };
-          var constraint = new Constraint({
-            foo: [ new Assert().NotBlank('This field is required') ],
-          });
-
-          var result = constraint.getErrorMessages( constraint.check( object ) );
-
-          expect( result ).to.have.key( 'foo' );
-          expect( result ).to.eql( {
-            foo: [ 'This field is required' ]
-          } );
-
-        } )
-
-        it( 'should give error for missing property', function() {
-
-          var object = { baz: 'a' };
-          var constraint = new Constraint({
-            foo: [ new Assert().Required('This field is required') ],
-            bar: [ new Assert().Required('This field is required') ],
-            baz: [ new Assert().Required('This field is required') ]
-          });
-
-          var result = constraint.getErrorMessages( constraint.check( object ) );
-
-          expect( result ).to.have.key( 'foo' );
-          expect( result ).to.have.key( 'bar' );
-          expect( result ).not.to.have.key( 'baz' );
-          expect( result ).to.eql( {
-            foo: [ 'This field is required' ],
-            bar: [ 'This field is required' ],
-          } );
-
-        } )
-
-        it( 'should give a message for a collection', function() {
-
-        } )
-
-        it( 'should give error for nested objects', function() {
-
-        } )
-
-      } )
-
     } )
   } )
 }


### PR DESCRIPTION
Solves [Issue #44](https://github.com/guillaumepotier/validator.js/issues/44)

Now you can 

```javascript
var  rules = {
  name: [ new Validator.Assert().Length( { min: 10 }, 'Please complete the name with more than 10 characters' ) ],
  email: [ new Validator.Assert().NotBlank('This email is invalid') ],
  lastname: [new Assert().IsString('The lastname must be a valid string')]
};

var model = {
  name: 'Mike',
  lastname: 'Perez'
};

var constraint = new Constraint(rules)
constraint.check(model).messages
constraint.getErrorMessages(validations)
```

and get: 

```javascript
{
  name: ['Please complete the name with more than 10 characters'],
  email: ['This email is invalid']
}
```

I didn't update the documentation but all assertions now have message as the last argument. This solves my problem but I don't know if it covers all posible cases. 


