### PR TITLE
Fix Collection handling of array of assertions

### DIFF
--- a/src/validator.js
+++ b/src/validator.js
@@ -546,7 +546,7 @@
 
     Collection: function ( assertOrConstraint ) {
       this.__class__ = 'Collection';
-      this.constraint = 'undefined' !== typeof assertOrConstraint ? (assertOrConstraint instanceof Assert ? assertOrConstraint : new Constraint( assertOrConstraint )) : false;
+      this.constraint = _isPlainObject( assertOrConstraint ) ? new Constraint( assertOrConstraint ) : assertOrConstraint;
 
       this.validate = function ( collection, group ) {
         var result, validator = new Validator(), count = 0, failures = {}, groups = this.groups.length ? this.groups : group;
@@ -996,6 +996,10 @@
 
   var _isArray = function ( obj ) {
     return Object.prototype.toString.call( obj ) === '[object Array]';
+  };
+
+  var _isPlainObject = function ( obj ) {
+    return typeof obj === 'object' && Object.getPrototypeOf( obj ) === Object.prototype;
   };
 
   var _isString = function (str ) {

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -504,6 +504,35 @@ var Suite = function ( Validator, expect, extras ) {
         expect( result.strings[ 0 ][ 0 ].assert.__class__ ).to.be( 'IsString' );
       } )
 
+      it( 'Collection with assert array', function () {
+        var object = {
+            foo: null,
+            items: [
+              'foo',
+              'bar@qux.com',
+              'baz'
+            ]
+          },
+          constraint = {
+            foo: new Assert().NotNull(),
+            items: new Assert().Collection( [ new Assert().NotEqualTo('foo'), new Assert().Email() ] )
+          };
+
+        var result = validator.validate( object, constraint );
+
+        expect( result ).to.have.key( 'foo' );
+        expect( result ).to.have.key( 'items' );
+        expect( result.items[ 0 ] ).to.have.key( '0' );
+        expect( result.items[ 0 ] ).not.to.have.key( '1' );
+        expect( result.items[ 0 ] ).to.have.key( '2' );
+        expect( result.items[ 0 ][ 0 ][ 0 ] ).to.be.a( Violation );
+        expect( result.items[ 0 ][ 0 ][ 0 ].assert.__class__ ).to.be( 'NotEqualTo' );
+        expect( result.items[ 0 ][ 0 ][ 1 ] ).to.be.a( Violation );
+        expect( result.items[ 0 ][ 0 ][ 1 ].assert.__class__ ).to.be( 'Email' );
+        expect( result.items[ 0 ][ 2 ][ 0 ] ).to.be.a( Violation );
+        expect( result.items[ 0 ][ 2 ][ 0 ].assert.__class__ ).to.be( 'Email' );
+      } )
+
       it( 'Collection with binded objects', function () {
         var itemConstraint = { foobar: new Assert().NotNull(), foobaz: new Assert().NotNull() },
           object = {


### PR DESCRIPTION
Fixes an issue when validating a Collection with an array of assertions:

I.e.:

```js
validate({
  foo: ['foobar']
}, {
  foo: new Assert().Collection([new Assert().IsString(), new Assert().Length(3)])
})
```

would crash with:

    Error: You must give an Assert or an Asserts array to validate a string