### PR TITLE
Beautify constructors

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # validator.js
 
-Powerful objects and strings validation in javascript for Node and the browser
+Powerful objects and strings validation in javascript for Node and modern browsers (evergreen browsers).
 
 ## Version
 
@@ -35,14 +35,19 @@ MIT - See LICENSE.md
 ## General usage
 
 - On node:
+
 ```
 $ npm install -g validator.js
 ```
+
 Then
+
 ```js
-Validator = require( 'validator.js' );
+var Validator = require( 'validator.js' );
 ```
+
 - On browser:
+
 ```js
 <script src="../validator.js"></script>
 <script>
@@ -53,37 +58,38 @@ Validator = require( 'validator.js' );
 ## Validate a string
 
 ```js
-var Assert = Validator.Assert;
+var is = require( 'validator.js' ).Assert;
+var validator = require( 'validator.js' ).validator();
 
-Validator.Validator().validate( 'foo', new Assert().Length( { min: 4 } ) );
-Validator.Validator().validate( 'foo', [ new Assert().Length( { min: 4 } ), new Assert().Email() ] );
-
+validator.validate( 'foo', is.ofLength( { min: 4 } ) );
+validator.validate( 'foo', [ is.ofLength( { min: 4 } ), is.email() ] );
 ```
+
 will return `true` if validation passes, a `Violation`'s array otherwise.
 
 ## Validate an object
 
 ```js
-var Assert = Validator.Assert,
-    validator = new Validator.Validator();
+var is = require( 'validator.js' ).Assert;
+var validator = require( 'validator.js' ).validator();
 
 var object = {
     name: 'john doe',
     email: 'wrong@email',
-    firstname: null,
+    firstName: null,
     phone: null
   },
   constraint = {
-    name:      [ new Assert().NotBlank(), new Assert().Length( { min: 4, max: 25 } ) ],
-    email:     new Assert().Email(),
-    firstname: new Assert().NotBlank(),
-    phone:     new Assert().NotBlank()
+    name: [ is.notBlank(), is.ofLength( { min: 4, max: 25 } ) ],
+    email: is.email(),
+    firstName: is.notBlank(),
+    phone: is.notBlank()
   };
 
 validator.validate( object, constraint );
 ```
-will return `true` if validation passes,
-`{ email: [ Violation ], firstname: [ Violation ] }` in this case.
+
+will return `true` if validation passes, `{ email: [ Violation ], firstname: [ Violation ] }` in this case.
 
 ## Validation groups
 
@@ -91,15 +97,17 @@ With same objects than above, just by adding validation groups:
 
 ```js
   constraint = {
-    name:      [ new Assert().NotBlank(), new Assert( 'edit' ).Length( { min: 4, max: 25 } ) ],
-    email:     new Assert().Email(),
-    firstname: new Assert( [ 'edit', 'register'] ).NotBlank(),
-    phone:     new Assert( 'edit' ).NotBlank()
+    name:      [ is.notBlank(), is( 'edit' ).ofLength( { min: 4, max: 25 } ) ],
+    email:     is.email(),
+    firstname: is( [ 'edit', 'register'] ).notBlank(),
+    phone:     is( 'edit' ).notBlank()
   };
 
 validator.validate( object, constraint, 'edit' );
 ```
+
 will return `true` in this case `{ firstname: [ Violation ], phone: [ Violation ] }`.
+
 There are two special groups: "Any" and "Default". Validating against `"Any"` group will validate
 against all Asserts, regardless their groups. Validating against `"Default"` group will only
 validate against Asserts that do not have a validation group.
@@ -107,9 +115,10 @@ validate against Asserts that do not have a validation group.
 ## Bind a constraint to an object
 
 ```js
-Validator.bind( object, constraint );
-Validator.validate( object, groups );
+validator.bind( object, constraint );
+validator.validate( object, groups );
 ```
+
 Under the hood, by default, a `_validatorjsConstraint` key will be created in object
 in order to store here the constraint. You could override this default key name by
 passing an option to Validator constructor.
@@ -124,10 +133,11 @@ Validator.js (see below), but you can implement yours for your needs using the
 `Callback()` assert (see below).
 
 ```js
-var length = new Validator.Assert().Length( { min: 10 } );
+var length = is.ofLength( { min: 10 } );
 try {
   length.check( 'foo' );
-} catch ( violation ) {}
+} catch ( violation ) {
+}
 ```
 
 ## Constraint definition
@@ -135,9 +145,9 @@ try {
 A Constraint is a set of asserts nodes that would be used to validate an object.
 
 ```js
-var length = new Validator.Assert().Length( { min: 10 } );
-var notBlank = new Validator.Assert().NotBlank();
-var constraint = new Constraint( { foo: length, bar: notBlank } );
+var length = is.ofLength( { min: 10 } );
+var notBlank = is.notBlank();
+var constraint = validator.constraint( { foo: length, bar: notBlank } );
 
 constraint.check( { foo: 'foo', bar: 'bar' } );
 ```
@@ -151,14 +161,14 @@ an optional parameter to your Constraint:
 
 ```js
 var object = {
-    foo: 'foo',
-    bar: 'bar'
+  foo: 'foo',
+  bar: 'bar'
 };
 
-var constraint = new Constraint( {
-    foo: new Assert().NotBlank(),
-    bar: new Assert().NotBlank(),
-    baz: new Assert().NotBlank()
+var constraint = validator.constraint( {
+  foo: is.notBlank(),
+  bar: is.notBlank(),
+  baz: is.notBlank()
 }, { strict: true });
 
 constraint.check( object );
@@ -175,14 +185,15 @@ constraints, no matter the validated object, you have to enable the `deepRequire
 ```js
 var object = { };
 
-var constraint = new Constraint({
+var constraint = validator.constraint({
   foo: {
-    bar: new Assert().Required()
+    bar: is.required()
   }
 }, { deepRequired: true });
 
 constraint.check(object);
 ```
+
 will return a `HaveProperty` Violation, saying that `foo` property does not exist.
 
 This option also works when `Collection` is used, but doesn't enforce a non empty array
@@ -190,44 +201,43 @@ on the validated object.
 
 ## Available asserts
 
-```js
-new Assert().Blank();
-new Assert().Callback( fn ( value ) {} [, arg1 ...] );
-new Assert().Choice( [] );
-new Assert().Choice( fn () {} );
-new Assert().Collection ( Assert );
-new Assert().Collection ( Constraint );
-new Assert().Count( value );
-new Assert().Count( fn ( [] ) {} );
-new Assert().Email();
-new Assert().EqualTo( value );
-new Assert().EqualTo( fn ( value ) {} );
-new Assert().GreaterThan( threshold );
-new Assert().GreaterThanOrEqual( threshold );
-new Assert().InstanceOf( classRef );
-new Assert().IsString();
-new Assert().Length( { min: value, max: value } );
-new Assert().HaveProperty( propertyName );
-new Assert().LessThan( threshold );
-new Assert().LessThanOrEqual( threshold );
-new Assert().EqualTo( value );
-new Assert().EqualTo( fn ( value ) {} );
-new Assert().NotBlank();
-new Assert().NotEqualTo( value );
-new Assert().NotNull();
-new Assert().Null();
-new Assert().Range( min, max );
-new Assert().Regexp( value );
-new Assert().Required();
-new Assert().Unique();
-new Assert().Unique( { key: value } );
+- Blank() (alias: `blank`)
+- Callback( fn ( value ) {} [, arg1 ...] ) (alias: `callback`)
+- Choice( [] ) (alias: `choice`)
+- Choice( fn () {} ) (alias: `choice`)
+- Collection ( Assert ) (alias: `collection`)
+- Collection ( Constraint ) (alias: `collection`)
+- Count( value ) (alias: `count`)
+- Count( fn ( [] ) {} ) (alias: `count`)
+- Email() (alias: `email`)
+- EqualTo( value ) (alias: `equalTo`)
+- EqualTo( fn ( value ) {} ) (alias: `equalTo`)
+- GreaterThan( threshold ) (alias: `greaterThan`)
+- GreaterThanOrEqual( threshold ) (alias: `greaterThanOrEqual`)
+- InstanceOf( classRef ) (alias: `instanceOf`)
+- IsString() (alias: `isString`)
+- Length( { min: value, max: value } ) (alias: `length`)
+- HaveProperty( propertyName ) (alias: `haveProperty`)
+- LessThan( threshold ) (alias: `lessThan`)
+- LessThanOrEqual( threshold ) (alias: `lessThanOrEqual`)
+- EqualTo( value ) (alias: `equalTo`)
+- EqualTo( fn ( value ) {} ) (alias: `equalTo`)
+- NotBlank() (alias: `notBlank`)
+- NotEqualTo( value ) (alias: `notEqualTo`)
+- NotNull() (alias: `notNull`)
+- Null() (alias: `null`)
+- Range( min, max ) (alias: `range`)
+- Regexp( value ) (alias: `regexp`)
+- Required() (alias: `required`)
+- Unique() (alias: `unique`)
+- Unique( { key: value } ) (alias: `unique`)
 
-// in extras.js
-new Assert().Eql( object );
-new Assert().Eql( fn ( value ) {} );
-new Assert().IPv4();
-new Assert().Mac();
-```
+### Additional asserts via extras.js
+
+- Eql( object ) (alias: `eql`)
+- Eql( fn ( value ) {} ) (alias: `eql`)
+- IPv4() (alias: `ipv4`)
+- Mac() (alias: `mac`)
 
 ### Community-driven asserts
 
@@ -245,7 +255,7 @@ Here is an example of test suite test showing how this assert works:
 
 ```js
 it( 'Collection', function () {
-  var itemConstraint = new Constraint( { foobar: new Assert().NotNull(), foobaz: new Assert().NotNull() } ),
+  var itemConstraint = validator.constraint( { foobar: is.notNull(), foobaz: is.notNull() } ),
     object = {
       foo: null,
       items: [
@@ -255,8 +265,8 @@ it( 'Collection', function () {
       ]
     },
     constraint = {
-      foo: new Assert().NotNull(),
-      items: [ new Assert().Collection( itemConstraint ), new Assert().Count( 2 ) ]
+      foo: is.notNull(),
+      items: [ is.collection( itemConstraint ), is.count( 2 ) ]
     };
 
   var result = validator.validate( object, constraint );
@@ -283,7 +293,7 @@ Here is an example from test suite test showing how this assert works:
 
 ```js
 it( 'Callback', function () {
-  assert = new Assert().Callback( function ( value ) {
+  assert = is.callback( function ( value ) {
     var calc = ( 42 / value ) % 2;
 
     return calc ? true : calc;
@@ -294,7 +304,7 @@ it( 'Callback', function () {
   expect( validate( 42, assert ) ).to.be( true );
 
   // improved Callback
-  assert = new Assert().Callback( function ( value, string1, string2 ) {
+  assert = is.callback( function ( value, string1, string2 ) {
     return value + string1 + string2 === 'foobarbaz';
   }, 'bar', 'baz' );
   expect( validate( 'foo', assert ) ).to.be( true );
@@ -304,12 +314,11 @@ it( 'Callback', function () {
 
 ### A note on type checking
 Note that `Length` assertion works for both String and Array type, so if you want to validate only strings, you should write an additional assertion:
-```js
-var Assert = Validator.Assert;
 
-Validator.Validator().validate( 'foo', [
-  new Assert().Length( { min: 4, max: 100 } ),
-  new Assert().IsString()
+```js
+validator.validate( 'foo', [
+  is.ofLength( { min: 4, max: 100 } ),
+  is.string()
 ] );
 ```
 
@@ -321,19 +330,17 @@ Example:
 
 ```js
 var Assert = Validator.Assert;
-var ExtendedAssert = Assert.extend({
-  Integer: Number.isInteger,
+var isExtended = Assert.extend({
+  integer: Number.isInteger,
   NaN: Number.isNaN
 });
 
-expect( validate( 10, new ExtendedAssert().Integer() ).to.be( true );
+expect( validate( 10, isExtended.integer() ).to.be( true );
 ```
 
 ## Run Tests
 
 - On node:
-  - `npm install mocha`
-  - `npm install expect.js`
   - `mocha tests/server.js`
 
 - On browser:

--- a/package.json
+++ b/package.json
@@ -27,8 +27,7 @@
     "grunt-contrib-uglify": "~0.2.7",
     "grunt-contrib-clean": "~0.5.0",
     "grunt-replace": "~0.5.1",
-    "grunt-npm2bower-sync": "~0.3.0",
-    "sinon": "~1.14.1"
+    "grunt-npm2bower-sync": "~0.3.0"
   },
   "scripts": {
     "build": "grunt build",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "scripts": {
     "build": "grunt build",
-    "test": "mocha tests/server.js -R dot",
+    "test": "mocha tests/server.js",
     "test-dist": "mocha tests/server.min.js -R dot"
   }
 }

--- a/src/extras.js
+++ b/src/extras.js
@@ -12,60 +12,62 @@
     factory( window[ 'undefined' !== typeof validatorjs_ns ? validatorjs_ns : 'Validator' ] ); // Browser global
   }
 }( function ( validator ) {
-  validator.Assert.prototype.Eql = function ( eql ) {
-    this.__class__ = 'Eql';
+  var asserts = {
+    Eql: function ( eql ) {
+      this.__class__ = 'Eql';
 
-    if ( 'undefined' === typeof eql )
-      throw new Error( 'Equal must be instanciated with an Array or an Object' );
+      if ( 'undefined' === typeof eql )
+        throw new Error( 'Equal must be instanciated with an Array or an Object' );
 
-    this.eql = eql;
+      this.eql = eql;
 
-    this.validate = function ( value ) {
-      var eql = 'function' === typeof this.eql ? this.eql( value ) : this.eql;
+      this.validate = function ( value ) {
+        var eql = 'function' === typeof this.eql ? this.eql( value ) : this.eql;
 
-      if ( !expect.eql( eql, value ) )
-        throw new validator.Violation( this, value, { eql: eql } );
+        if ( !expect.eql( eql, value ) )
+          throw new validator.Violation( this, value, { eql: eql } );
 
-      return true;
-    };
+        return true;
+      };
 
-    return this;
-  };
+      return this;
+    },
 
-  validator.Assert.prototype.Mac = function () {
-    this.__class__ = 'Mac';
+    Mac: function () {
+      this.__class__ = 'Mac';
 
-    this.validate = function ( value ) {
-      var regExp = /^(?:[0-9A-F]{2}:){5}[0-9A-F]{2}$/i;
+      this.validate = function ( value ) {
+        var regExp = /^(?:[0-9A-F]{2}:){5}[0-9A-F]{2}$/i;
 
-      if ( 'string' !== typeof value )
-        throw new validator.Violation( this, value, { value: Validator.errorCode.must_be_a_string } );
+        if ( 'string' !== typeof value )
+          throw new validator.Violation( this, value, { value: Validator.errorCode.must_be_a_string } );
 
-      if ( !regExp.test( value ) )
-        throw new validator.Violation( this, value );
+        if ( !regExp.test( value ) )
+          throw new validator.Violation( this, value );
 
-      return true;
-    };
+        return true;
+      };
 
-    return this;
-  };
+      return this;
+    },
 
-  validator.Assert.prototype.IPv4 = function () {
-    this.__class__ = 'IPv4';
+    IPv4: function () {
+      this.__class__ = 'IPv4';
 
-    this.validate = function ( value ) {
-      var regExp = /^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/;
+      this.validate = function ( value ) {
+        var regExp = /^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/;
 
-      if ( 'string' !== typeof value )
-        throw new validator.Violation( this, value, { value: Validator.errorCode.must_be_a_string } );
+        if ( 'string' !== typeof value )
+          throw new validator.Violation( this, value, { value: Validator.errorCode.must_be_a_string } );
 
-      if ( !regExp.test( value ) )
-        throw new validator.Violation( this, value );
+        if ( !regExp.test( value ) )
+          throw new validator.Violation( this, value );
 
-      return true;
-    };
+        return true;
+      };
 
-    return this;
+      return this;
+    }
   };
 
   // https://github.com/LearnBoost/expect.js/blob/master/expect.js
@@ -145,4 +147,6 @@
       }
     }
   };
+
+  return validator.Assert.extend(asserts);
 } ) );

--- a/src/validator.js
+++ b/src/validator.js
@@ -965,12 +965,6 @@
     }
   };
 
-  // expose to the world these awesome classes
-  exports.Assert = Assert;
-  exports.Validator = Validator;
-  exports.Violation = Violation;
-  exports.Constraint = Constraint;
-
   /**
   * Some useful object prototypes / functions here
   */
@@ -1027,6 +1021,28 @@
 
   var _isString = function (str ) {
     return Object.prototype.toString.call( str ) === '[object String]';
+  };
+
+  // expose to the world these awesome classes
+  exports.Assert = Assert;
+  exports.Constraint = Constraint;
+  exports.Validator = Validator;
+  exports.Violation = Violation;
+
+  exports.assert = function( group ) {
+    return new Assert( group );
+  };
+
+  exports.constraint = function( data, options ) {
+    return new Constraint( data, options );
+  };
+
+  exports.validator = function( options ) {
+    return new Validator( options );
+  };
+
+  exports.violation = function( assert, value, violation ) {
+    return new Violation( assert, value, violation );
   };
 
   // AMD export

--- a/src/validator.js
+++ b/src/validator.js
@@ -368,6 +368,11 @@
     Extended.prototype = Object.create( Assert.prototype );
     Extended.prototype.constructor = Extended;
 
+    // Copy all the static methods.
+    Object.keys( Assert ).forEach( function( key ) {
+      Extended[ key ] = Assert[ key ];
+    } );
+
     // Extend with custom asserts.
     for ( var key in asserts ) {
       if ( 'function' !== typeof asserts[ key ] )

--- a/src/validator.js
+++ b/src/validator.js
@@ -13,7 +13,11 @@
   * Validator
   */
 
-  var Validator = function ( options ) {
+  function Validator ( options ) {
+    if ( ! ( this instanceof Validator ) ) {
+      return new Validator( options );
+    }
+
     this.__class__ = 'Validator';
     this.__version__ = '@@version';
     this.options = options || {};
@@ -119,7 +123,11 @@
   * Constraint
   */
 
-  var Constraint = function ( data, options ) {
+  function Constraint ( data, options ) {
+    if ( ! ( this instanceof Constraint ) ) {
+      return new Constraint( data, options );
+    }
+
     this.__class__ = 'Constraint';
     this.options = options || {};
     this.nodes = {};
@@ -290,7 +298,11 @@
   * Violation
   */
 
-  var Violation = function ( assert, value, violation ) {
+  function Violation ( assert, value, violation ) {
+    if ( ! ( this instanceof Violation ) ) {
+      return new Violation( assert, value, violation );
+    }
+
     this.__class__ = 'Violation';
 
     if ( ! ( assert instanceof Assert ) )
@@ -340,7 +352,10 @@
   * Assert
   */
 
-  var Assert = function ( group ) {
+  function Assert ( group ) {
+    if ( ! ( this instanceof Assert ) )
+      return new Assert( group );
+
     this.__class__ = 'Assert';
     this.__parentClass__ = this.__class__;
     this.groups = [];

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -287,6 +287,10 @@ var Suite = function ( validatorjs, expect, AssertExtra ) {
         expect( validate( { bar: 'baz' }, assert ) ).not.to.be( true );
       } )
 
+      it( 'HaveProperty alias PropertyDefined', function () {
+        expect( new Assert().HaveProperty( 'foo' ).__class__ ).to.eql( new Assert().PropertyDefined( 'foo' ).__class__ );
+      } )
+
       it( 'Length', function () {
         assert = new Assert().Length( { min: 3 } );
 
@@ -319,6 +323,10 @@ var Suite = function ( validatorjs, expect, AssertExtra ) {
         expect( validator.validate(['foo'], assert) ).not.to.be( true );
         expect( validator.validate(['foo', 'bar', 'baz'], assert) ).to.be( true );
         expect( validator.validate(['foo', 'bar', 'baz', 'qux', 'bux', 'pux'], assert) ).not.to.be( true );
+      } )
+
+      it( 'Length alias OfLength', function () {
+        expect( new Assert().Length( { min: 0, max: 1 } ).__class__ ).to.eql( new Assert().OfLength( { min: 0, max: 1 } ).__class__ );
       } )
 
       it( 'Email', function () {
@@ -360,6 +368,10 @@ var Suite = function ( validatorjs, expect, AssertExtra ) {
         expect( validate( [1, 2, 3], assert ) ).not.to.be( true );
         expect( validate( [1, 2, 3], assert ).show() ).to.eql( { assert: 'IsString', value: [1, 2, 3], violation: { value: 'must_be_a_string' } } );
         expect( validate( [1, 2, 3], assert ).__toString() ).to.eql( 'IsString assert failed for "1,2,3", value expected was must_be_a_string' );
+      } )
+
+      it( 'IsString alias String', function () {
+        expect( new Assert().IsString( 'foo' ).__class__ ).to.eql( new Assert().String( 'foo' ).__class__ );
       } )
 
       it( 'EqualTo', function () {

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -76,6 +76,13 @@ var Suite = function ( Validator, expect, AssertExtra ) {
           }
         } )
 
+        it( 'should inherit `Assert` static methods', function () {
+          var fn = function() {};
+          var Extended = Assert.extend({ Foobar: fn });
+
+          expect( Extended ).to.have.keys( Object.keys( Assert ) );
+        } )
+
         it( 'should return an Assert extended copy and keep the original `Assert.prototype` unchanged', function () {
           var fn = function() {};
           var Extended = Assert.extend({ Foobar: fn });

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -20,9 +20,33 @@ var Suite = function ( validatorjs, expect, AssertExtra ) {
 
       describe('static constructor', function() {
         it( 'should create an instance of `Assert`', function () {
-          expect( validatorjs.assert() ).to.be.an( Assert );
+          var assert = validatorjs.assert( 'foobar' );
+
+          expect( assert ).to.be.an( Assert );
+          expect( assert.groups ).to.eql( ['foobar'] );
         } )
       } )
+
+      describe( 'static methods', function () {
+        it('should create an instance of `Assert`', function () {
+          var assert = Assert.Range( 5, 10 );
+
+          expect( assert ).to.be.an( Assert );
+          expect( assert.__class__ ).to.be( 'Range' );
+          expect( assert.min ).to.be( 5 );
+          expect( assert.max ).to.be( 10 );
+        });
+
+        it('should have a camel case alias', function () {
+          expect( Assert.NotBlank().__class__ ).to.be( Assert.notBlank().__class__ );
+        });
+
+        it('should create new instances', function () {
+          const assert = Assert.NotBlank();
+
+          expect( assert ).to.not.equal( Assert.notBlank() );
+        });
+      });
 
       describe( 'extend', function() {
         it( 'should throw an error if the extend parameter is missing', function () {
@@ -194,7 +218,11 @@ var Suite = function ( validatorjs, expect, AssertExtra ) {
 
       describe('static constructor', function() {
         it( 'should create an instance of `Violation`', function () {
-          expect( validatorjs.violation( new Assert().NotBlank(), '' ) ).to.be.an( Violation );
+          var notNullViolation = new Violation( new Assert().NotNull() );
+          var violation = validatorjs.violation( new Assert().NotBlank(), '', notNullViolation );
+
+          expect( notNullViolation ).to.be.an( Violation );
+          expect( violation.violation ).to.equal( notNullViolation );
         } )
       } )
 
@@ -762,7 +790,11 @@ var Suite = function ( validatorjs, expect, AssertExtra ) {
 
       describe('static constructor', function() {
         it( 'should create an instance of `Constraint`', function () {
-          expect( validatorjs.constraint() ).to.be.an( Constraint );
+          var constraint = validatorjs.constraint( { foo: new Assert().NotBlank() }, { bar: 'biz' } );
+
+          expect( constraint ).to.be.an( Constraint );
+          expect( constraint.nodes ).to.have.key( 'foo' );
+          expect( constraint.options ).to.have.property( 'bar', 'biz' );
         } )
       } )
 
@@ -859,7 +891,10 @@ var Suite = function ( validatorjs, expect, AssertExtra ) {
 
       describe('static constructor', function() {
         it( 'should create an instance of `Validator`', function () {
-          expect( validatorjs.validator() ).to.be.an( Validator );
+          var validator = validatorjs.validator( { foo: 'bar' } );
+
+          expect( validator ).to.be.an( Validator );
+          expect( validator.options ).to.have.property('foo', 'bar');
         } )
       } )
 

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -3,7 +3,7 @@ var sinon = require('sinon');
 
 ( function ( exports ) {
 
-var Suite = function ( Validator, expect, extras ) {
+var Suite = function ( Validator, expect, AssertExtra ) {
   describe( 'Validator', function () {
     var validator = new Validator.Validator(),
       Violation = Validator.Violation,
@@ -675,12 +675,12 @@ var Suite = function ( Validator, expect, extras ) {
         expect( validate( 7, assert ).show() ).to.eql( { assert: 'LessThanOrEqual', value: 7, violation: { threshold: 5 } } );
       } )
 
-      if ( !extras )
+      if ( !AssertExtra )
         return;
 
       describe ('Extras Asserts', function () {
         it( 'Mac', function () {
-          assert = new Assert().Mac();
+          assert = new AssertExtra().Mac();
 
           expect( validate( '0G:42:AT:F5:OP:Z2', assert ) ).not.to.be( true );
           expect( validate( 'AD:32:11:F7:3B', assert ) ).not.to.be( true );
@@ -690,7 +690,7 @@ var Suite = function ( Validator, expect, extras ) {
         } )
 
         it( 'IPv4', function () {
-          assert = new Assert().IPv4();
+          assert = new AssertExtra().IPv4();
 
           expect( validate( 'foo.bar', assert ) ).not.to.be( true );
           expect( validate( '192.168.1', assert ) ).not.to.be( true );
@@ -700,7 +700,7 @@ var Suite = function ( Validator, expect, extras ) {
         } )
 
         it( 'Eql', function () {
-          assert = new Assert().Eql( { foo: 'foo', bar: 'bar' } );
+          assert = new AssertExtra().Eql( { foo: 'foo', bar: 'bar' } );
 
           expect( validate( 'foo', assert) ).not.to.be( true );
           expect( validate( 'foo', assert ).show() ).to.eql( { assert: 'Eql', value: 'foo', violation: { eql: { foo: 'foo', bar: 'bar' } } } );
@@ -710,7 +710,7 @@ var Suite = function ( Validator, expect, extras ) {
         } )
 
         it( 'Eql w/ function', function () {
-          assert = new Assert().Eql( function ( value ) { return { foo: 'foo', bar: 'bar' } } );
+          assert = new AssertExtra().Eql( function ( value ) { return { foo: 'foo', bar: 'bar' } } );
 
           expect( validate( { foo: null, bar: null }, assert ) ).not.to.be( true );
           expect( validate( { foo: 'foo', bar: 'bar' }, assert ) ).to.be( true );

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -1,6 +1,3 @@
-
-var sinon = require('sinon');
-
 ( function ( exports ) {
 
 var Suite = function ( validatorjs, expect, AssertExtra ) {
@@ -65,20 +62,11 @@ var Suite = function ( validatorjs, expect, AssertExtra ) {
         } )
 
         it( 'should call the `Assert` constructor', function () {
-          sinon.spy(Assert, 'apply');
-
           var fn = function() {};
           var Extended = Assert.extend({ Foobar: fn });
+          var extended = new Extended('foobar');
 
-          new Extended();
-
-          expect(Assert.apply.callCount).to.equal(1);
-          expect(Assert.apply.firstCall.args[0].__class__).to.equal('Assert');
-          expect(Assert.apply.firstCall.args[0].__parentClass__).to.equal('Assert');
-          expect(Assert.apply.firstCall.args[0].groups).to.eql([]);
-
-          // Restore spy.
-          Assert.apply.restore();
+          expect( extended.groups ).to.eql( ['foobar' ]);
         } )
 
         it( 'should inherit the `Assert` prototype', function () {

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -3,15 +3,23 @@ var sinon = require('sinon');
 
 ( function ( exports ) {
 
-var Suite = function ( Validator, expect, AssertExtra ) {
-  describe( 'Validator', function () {
-    var validator = new Validator.Validator(),
-      Violation = Validator.Violation,
-      Assert = Validator.Assert,
-      Constraint = Validator.Constraint;
+var Suite = function ( validatorjs, expect, AssertExtra ) {
+  describe( 'validator.js', function () {
+    var Assert = validatorjs.Assert,
+      Constraint = validatorjs.Constraint,
+      Validator = validatorjs.Validator,
+      Violation = validatorjs.Violation;
+
+    var validator = new validatorjs.Validator();
 
     describe( 'Assert', function () {
       var assert = new Assert();
+
+      describe( 'constructor', function () {
+        it( 'should not require the new keyword', function () {
+          expect( Assert() ).to.be.an( Assert );
+        } )
+      } )
 
       describe( 'extend', function() {
         it( 'should throw an error if the extend parameter is missing', function () {
@@ -50,7 +58,7 @@ var Suite = function ( Validator, expect, AssertExtra ) {
           }
         } )
 
-        it('should call the `Assert` constructor', function () {
+        it( 'should call the `Assert` constructor', function () {
           sinon.spy(Assert, 'apply');
 
           var fn = function() {};
@@ -182,7 +190,13 @@ var Suite = function ( Validator, expect, AssertExtra ) {
     } )
 
     describe( 'Violation', function () {
-      var violation = new Validator.Violation( new Assert().NotBlank(), '' );
+      var violation = new Violation( new Assert().NotBlank(), '' );
+
+      describe( 'constructor', function () {
+        it( 'should not require the new keyword', function () {
+          expect( Violation( new Assert().NotBlank(), '' ) ).to.be.an( Violation );
+        } )
+      } )
 
       it( 'should be an object', function () {
         expect( violation ).to.be.an( 'object' );
@@ -194,7 +208,7 @@ var Suite = function ( Validator, expect, AssertExtra ) {
 
       it( 'should fail if not instanciated with an Assert object having __class__', function () {
         try {
-          var violation = new Validator.Violation( 'foo' );
+          var violation = new Violation( 'foo' );
           expect().fail();
         } catch ( err ) {
           expect( err.message ).to.be( 'Should give an assertion implementing the Assert interface' );
@@ -685,7 +699,7 @@ var Suite = function ( Validator, expect, AssertExtra ) {
       if ( !AssertExtra )
         return;
 
-      describe ('Extras Asserts', function () {
+      describe( 'Extras Asserts', function () {
         it( 'Mac', function () {
           assert = new AssertExtra().Mac();
 
@@ -726,7 +740,13 @@ var Suite = function ( Validator, expect, AssertExtra ) {
     } )
 
     describe( 'Constraint', function () {
-      var constraint = new Validator.Constraint();
+      var constraint = new Constraint();
+
+      describe( 'constructor', function () {
+        it( 'should not require the new keyword', function () {
+          expect( Constraint() ).to.be.an( Constraint );
+        } )
+      } )
 
       it( 'should be an object', function () {
         expect( constraint ).to.be.an( 'object' );
@@ -737,7 +757,7 @@ var Suite = function ( Validator, expect, AssertExtra ) {
       } )
 
       it( 'should be instanciated without an assertion', function () {
-        var myConstraint = new Validator.Constraint();
+        var myConstraint = new Constraint();
         expect( myConstraint.nodes ).to.eql( {} );
       } )
 
@@ -813,6 +833,11 @@ var Suite = function ( Validator, expect, AssertExtra ) {
     } )
 
     describe( 'Validator', function () {
+      describe( 'constructor', function () {
+        it( 'should not require the new keyword', function () {
+          expect( Validator() ).to.be.an( Validator );
+        } )
+      } )
 
       it( 'should be an object', function () {
         expect( validator ).to.be.an( 'object' );
@@ -841,7 +866,7 @@ var Suite = function ( Validator, expect, AssertExtra ) {
           var asserts = [ new Assert().Length( { min: 5, max: 10 } ), new Assert().NotBlank() ];
           var violations = validator.validate( '', asserts );
           expect( violations ).to.have.length( 2 );
-          expect( violations[ 0 ] ).to.be.a( Validator.Violation );
+          expect( violations[ 0 ] ).to.be.a( validatorjs.Violation );
           expect( violations[ 0 ].assert.__class__ ).to.be( 'Length' );
           expect( violations[ 1 ].assert.__class__ ).to.be( 'NotBlank' );
           violations = validator.validate( 'foo', asserts );

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -21,6 +21,12 @@ var Suite = function ( validatorjs, expect, AssertExtra ) {
         } )
       } )
 
+      describe('static constructor', function() {
+        it( 'should create an instance of `Assert`', function () {
+          expect( validatorjs.assert() ).to.be.an( Assert );
+        } )
+      } )
+
       describe( 'extend', function() {
         it( 'should throw an error if the extend parameter is missing', function () {
           try {
@@ -195,6 +201,12 @@ var Suite = function ( validatorjs, expect, AssertExtra ) {
       describe( 'constructor', function () {
         it( 'should not require the new keyword', function () {
           expect( Violation( new Assert().NotBlank(), '' ) ).to.be.an( Violation );
+        } )
+      } )
+
+      describe('static constructor', function() {
+        it( 'should create an instance of `Violation`', function () {
+          expect( validatorjs.violation( new Assert().NotBlank(), '' ) ).to.be.an( Violation );
         } )
       } )
 
@@ -748,6 +760,12 @@ var Suite = function ( validatorjs, expect, AssertExtra ) {
         } )
       } )
 
+      describe('static constructor', function() {
+        it( 'should create an instance of `Constraint`', function () {
+          expect( validatorjs.constraint() ).to.be.an( Constraint );
+        } )
+      } )
+
       it( 'should be an object', function () {
         expect( constraint ).to.be.an( 'object' );
       } )
@@ -836,6 +854,12 @@ var Suite = function ( validatorjs, expect, AssertExtra ) {
       describe( 'constructor', function () {
         it( 'should not require the new keyword', function () {
           expect( Validator() ).to.be.an( Validator );
+        } )
+      } )
+
+      describe('static constructor', function() {
+        it( 'should create an instance of `Validator`', function () {
+          expect( validatorjs.validator() ).to.be.an( Validator );
         } )
       } )
 


### PR DESCRIPTION
This PR introduces a new simplified API to reduce the object construction *weight* of the current asserts.

The new API is completely optional and loosely inspired by the micro validation library [is.js](https://arasatasaygin.github.io/is.js/). The idea is to improve how asserts are created.

Before:

```js
var Assert = require('validator.js').Assert;

var object = {
  name: 'foo',
  email: 'bar',
  firstName: '',
  phone: null
},
constraint = {
  name: [new Assert().NotBlank(), new Assert().Length({ min: 4, max: 25 })],
  email: new Assert().Email(),
  firstName: new Assert().NotBlank(),
  phone: new Assert().NotBlank()
};
```

After:

```js
var is = require('validator.js').Assert;

var object = {
  name: 'foo',
  email: 'bar',
  firstName: '',
  phone: null
},
constraint = {
  name: [is.notBlank(), is.ofLength({ min: 4, max: 25 })],
  email: is.email(),
  firstName: is.notBlank(),
  phone: is.notBlank()
};
```

So, in short, just sugar for a more natural and concise API, resulting in more readable code (in my opinion). 

In the process of maturing this approach, some unrelated issues have also been fixed or changed:

- All asserts can be used in their `camelCase` form, e.g. `NotBlank`/`notBlank`. Special cases have also been handled (e.g. `IPv4`/`ipv4` instead of `iPv4`).
- Added the following aliases for a more fluent API:

  - `IsString` -> `String` (is.string())
  - `HaveProperty` -> `PropertyDefined` (is.propertyDefined())
  - `Length` -> `OfLength` (is.ofLength())

- The extra asserts available via `extras.js` were manipulating the `validator.js` module prototype directly instead of using the module's own extend (BC):

Before:

```js
( function ( validator ) {
  validator.Assert.prototype.Eql = function ( eql ) {
    this.__class__ = 'Eql';
```

After:

```js
( function ( validator ) {
  return validator.Assert.extend({
    Eql: function ( eql ) {
      this.__class__ = 'Eql';
    }
  })
```

- The `Assert` object which had been the result of an extension (i.e. instance of `Extended`) would not be extendable since static methods were not being copied over.


Before:

```js
var Assert = Validator.Assert;
var ExtendedAssert = Assert.extend({
  Integer: Number.isInteger,
  NaN: Number.isNaN
});

// TypeError
ExtendedAssert.extend({
  Finite: Number.isFinite
});
```

After:

```js
var Assert = Validator.Assert;
var ExtendedAssert = Assert.extend({
  Integer: Number.isInteger,
  NaN: Number.isNaN
});

var ExtendedAssertFinite = ExtendedAssert.extend({
  Finite: Number.isFinite
});

expect( validate( 10, new ExtendedAssertFinite().Finite() ).to.be( true );
```

- Constructors can now be instantiated using the upper or lower capital case wording and without the `new` keyword. This should allow more elegant module requiring (unless ES2015 modules are used).

Before:

```js
var Validator = require('validator.js');
var validator = new Validator.Validator();
```

After:

```js
var validator = require('validator.js').validator();
```

Tests are also passing.