### PR TITLE
Fix wrong length for astral code points

### DIFF
--- a/src/validator.js
+++ b/src/validator.js
@@ -717,6 +717,11 @@
       this.max = parseInt(boundaries.max);
 
       this.validate = function ( value ) {
+        if ( 'string' === typeof value ) {
+          var regexAstralSymbols = /[\uD800-\uDBFF][\uDC00-\uDFFF]/g;
+          value = value.replace( regexAstralSymbols, '_' );
+        }
+
         if ( 'string' !== typeof value && !_isArray( value ) )
           throw new Violation( this, value, { value: Validator.errorCode.must_be_a_string_or_array } );
 

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -109,6 +109,11 @@ var Suite = function ( Validator, expect, extras ) {
         expect( Length.validate( 'foo bar baz' ) ).to.be( true );
       } )
 
+      it( 'should return true if validate success with astral code points', function () {
+        var Length = new Assert().Length( { max: 1 } );
+        expect( Length.validate( '🤔' ) ).to.be( true );
+      } )
+
       it( 'should throw a Violation exception if fails', function () {
         var Length = new Assert().Length( { min: 10 } );
         try {


### PR DESCRIPTION
Because of the way Javascript deals with unicode characters, astral code points like some Chinese characters or emojis are marked as surrogate pairs, and are therefore counted as 2 separate characters:

``` js
> '👾'.length
2
```

This means that when using these characters, the limits in `Length` might not always be accurate.

This PR fixes that by identifying those astral symbols and replacing them with a simple unicode character (`_`). This solution was based on https://mathiasbynens.be/notes/javascript-unicode. Other solutions would require adding external dependencies.
