### PR TITLE
Fix groups on Extended method without context

### DIFF
--- a/src/validator.js
+++ b/src/validator.js
@@ -376,7 +376,10 @@
       throw new Error( 'Invalid parameter: `asserts` should have at least one property' );
 
     // Inherit from Assert.
-    function Extended() {
+    function Extended( group ) {
+      if ( ! ( this instanceof Extended ) )
+        return new Extended( group );
+
       Assert.apply( this, arguments );
     }
 

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -85,6 +85,13 @@ var Suite = function ( validatorjs, expect, AssertExtra ) {
           }
         } )
 
+        it( 'should not require the new keyword', function () {
+          var fn = function() {};
+          var Extended = Assert.extend({ Foobar: fn });
+
+          expect( Extended() ).to.be.an( Extended );
+        } )
+
         it( 'should call the `Assert` constructor', function () {
           var fn = function() {};
           var Extended = Assert.extend({ Foobar: fn });


### PR DESCRIPTION
This PR updates `Extended` method to implicitly create an instance if it's called without context. This way `Extended` can now be called without context (as `is`) to use validation groups (just like `Assert`), which currently throws an error.