### PR TITLE
Fix group support when using static asserts

### DIFF
--- a/src/validator.js
+++ b/src/validator.js
@@ -376,7 +376,10 @@
       throw new Error( 'Invalid parameter: `asserts` should have at least one property' );
 
     // Inherit from Assert.
-    function Extended() {
+    function Extended( group ) {
+      if ( ! ( this instanceof Extended ) )
+        return new Extended( group );
+
       Assert.apply( this, arguments );
     }
 
@@ -1045,16 +1048,22 @@
       }
 
       // Add static methods as aliases.
-      Fn[ camelCaseProperty ] = (function( prop ) {
-        return function() {
-          var assert = new Fn();
+      if (!(camelCaseProperty in Fn)) {
+        Fn[ camelCaseProperty ] = (function( prop ) {
+          return function() {
+            var assert = new Fn();
 
-          return assert[ prop ].apply( assert, arguments );
-        }
-      })( property );
+            return assert[ prop ].apply( assert, arguments );
+          }
+        })( property );
+
+        _alias( Fn, camelCaseProperty, property );
+      }
 
       // Create `camelCase` aliases.
-      _alias( Fn, camelCaseProperty, property );
+      if (!(camelCaseProperty in Fn.prototype)) {
+        _alias( Fn.prototype, property, camelCaseProperty );
+      }
     }
 
     return Fn;

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -28,24 +28,75 @@ var Suite = function ( validatorjs, expect, AssertExtra ) {
       } )
 
       describe( 'static methods', function () {
-        it('should create an instance of `Assert`', function () {
+        it( 'should create an instance of `Assert` ', function () {
           var assert = Assert.Range( 5, 10 );
 
           expect( assert ).to.be.an( Assert );
           expect( assert.__class__ ).to.be( 'Range' );
           expect( assert.min ).to.be( 5 );
           expect( assert.max ).to.be( 10 );
-        });
+        } );
 
-        it('should have a camel case alias', function () {
+        it( 'should have a camel case alias', function () {
           expect( Assert.NotBlank().__class__ ).to.be( Assert.notBlank().__class__ );
-        });
+        } );
 
-        it('should create new instances', function () {
+        it( 'should create new instances', function () {
           const assert = Assert.NotBlank();
 
           expect( assert ).to.not.equal( Assert.notBlank() );
-        });
+        } );
+
+        it( 'should support `extend`', function () {
+          const assert = Assert.extend({
+            Foobar: function() {
+              this.__class__ = 'Foobar';
+              this.validate = function() {
+                return false;
+              }
+
+              return this;
+            }
+          } ).Foobar();
+
+          expect( assert ).to.be.an( Assert );
+          expect( assert.__class__ ).to.be( 'Foobar' );
+        } );
+
+        it( 'should support groups', function () {
+          const assert1 = Assert('bizGroup').NotBlank();
+
+          expect( assert1 ).to.be.an( Assert );
+          expect( assert1.__class__ ).to.be( 'NotBlank' );
+          expect( assert1.groups ).to.eql( ['bizGroup'] );
+
+          const assert2 = Assert('fooGroup').notBlank();
+
+          expect( assert2 ).to.be.an( Assert );
+          expect( assert2.__class__ ).to.be( 'NotBlank' );
+          expect( assert2.groups ).to.eql( ['fooGroup'] );
+
+          var fn = function() {
+            this.__class__ = 'Foobar';
+            this.validate = function() {
+              return false;
+            }
+
+            return this;
+          }
+
+          const assert3 = Assert.extend({ Foobar: fn } )('barGroup').Foobar();
+
+          expect( assert3 ).to.be.an( Assert );
+          expect( assert3.__class__ ).to.be( 'Foobar' );
+          expect( assert3.groups ).to.eql( ['barGroup'] );
+
+          const assert4 = Assert.extend({ Foobar: fn } )('quxGroup').foobar();
+
+          expect( assert4 ).to.be.an( Assert );
+          expect( assert4.__class__ ).to.be( 'Foobar' );
+          expect( assert4.groups ).to.eql( ['quxGroup'] );
+        } );
       });
 
       describe( 'extend', function() {
@@ -83,6 +134,13 @@ var Suite = function ( validatorjs, expect, AssertExtra ) {
           } catch (err) {
             expect( err.message ).to.be( 'The extension assert must be a function' );
           }
+        } )
+
+        it( 'should not require the new keyword', function () {
+          var fn = function() {};
+          var Extended = Assert.extend({ Foobar: fn });
+
+          expect( Extended() ).to.be.an( Extended );
         } )
 
         it( 'should call the `Assert` constructor', function () {


### PR DESCRIPTION
This should work now:

```js
var is = require( './src/validator' ).Assert.extend({ Foobar: function() {
  this.__class__ = 'Foobar';
  this.validate = function() { return false; }
  return this;
}});

var validator = require( './src/validator' ).validator();

let constraint = {
    name:      [ is.notBlank(), is( 'edit' ).ofLength( { min: 4, max: 25 } ) ],
    email:     [ is('edit').foobar(), is.email() ],
    firstname: is( [ 'edit', 'register'] ).notNull(),
    phone:     is( 'edit' ).notBlank()
  };

console.log(require('util').inspect(validator.validate( {
    name: 'john doe',
    email: 'wrong@email.com',
    firstName: null,
    phone: null
  }, constraint), { depth: null }));
```