### PR TITLE
Add support for extending Assert static methods

### DIFF
--- a/src/validator.js
+++ b/src/validator.js
@@ -388,6 +388,11 @@
 
     // Copy all the static methods.
     Object.keys( Assert ).forEach( function( key ) {
+      // Allow extending static methods.
+      if ( Object.keys( asserts ).indexOf( _toPascalCase(key) ) !== -1 ) {
+        return;
+      }
+
       Extended[ key ] = Assert[ key ];
     } );
 
@@ -1072,6 +1077,13 @@
       .replace(/\s(.)/g, function( $1 ) { return $1.toUpperCase(); })
       .replace(/\s/g, '')
       .replace(/^(.)/, function( $1 ) { return $1.toLowerCase(); });
+  };
+
+  var _toPascalCase = function ( str ) {
+    return str
+      .replace(/\s(.)/g, function( $1 ) { return $1.toLowerCase(); })
+      .replace(/\s/g, '')
+      .replace(/^(.)/, function( $1 ) { return $1.toUpperCase(); });
   };
 
   var _prettify = function _prettify ( Fn ) {

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -167,6 +167,18 @@ var Suite = function ( validatorjs, expect, AssertExtra ) {
           expect( Extended ).to.have.keys( Object.keys( Assert ) );
         } )
 
+        it( 'should override `Assert` static methods', function () {
+          var Extended = Assert.extend({
+            Collection: function() {
+              this.__class__ = 'Foobar';
+              return this;
+            }
+          });
+
+          expect(Extended.Collection().__class__).to.be('Foobar');
+          expect(Extended.collection().__class__).to.be('Foobar');
+        } )
+
         it( 'should return an Assert extended copy and keep the original `Assert.prototype` unchanged', function () {
           var fn = function() {};
           var Extended = Assert.extend({ Foobar: fn });


### PR DESCRIPTION
This PR adds support for extending the `Assert` static methods, which now can be overrided to add extra validation logic.