### PR TITLE
Fix pretty asserts and static methods not updated on extends

### DIFF
--- a/src/validator.js
+++ b/src/validator.js
@@ -305,7 +305,7 @@
 
     this.__class__ = 'Violation';
 
-    if ( ! ( assert instanceof Assert ) )
+    if ( ! ( assert instanceof Assert || assert.__parentClass__ === 'Assert' ) )
       throw new Error( 'Should give an assertion implementing the Assert interface' );
 
     this.assert = assert;
@@ -1088,32 +1088,26 @@
         continue;
       }
 
-      // Add static methods as aliases.
-      if (!(camelCaseProperty in Fn)) {
-        Fn[ camelCaseProperty ] = (function( prop ) {
-          return function() {
-            var assert = new Fn();
-
-            return assert[ prop ].apply( assert, arguments );
-          }
-        })( property );
-
-        _alias( Fn, camelCaseProperty, property );
-      }
-
       // Create `camelCase` aliases.
-      if (!(camelCaseProperty in Fn.prototype)) {
-        _alias( Fn.prototype, property, camelCaseProperty );
-      }
+      _alias( Fn.prototype, property, camelCaseProperty );
+
+      // Add static methods as aliases.
+      Fn[ camelCaseProperty ] = (function( prop ) {
+        return function() {
+          var assert = new Fn();
+
+          return assert[ prop ].apply( assert, arguments );
+        }
+      })( property );
+
+      _alias( Fn, camelCaseProperty, property );
     }
 
     return Fn;
   };
 
   var _alias = function _alias ( object, from, to ) {
-    var descriptor = Object.getOwnPropertyDescriptor( object, from );
-
-    Object.defineProperty( object, to, descriptor );
+    object[ to ] = object[ from ];
   }
 
   // aliases

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -174,6 +174,20 @@ var Suite = function ( validatorjs, expect, AssertExtra ) {
           expect(Assert.prototype.Foobar).to.be(undefined);
           expect(Extended.prototype.Foobar).to.eql(fn);
         } )
+
+        it( 'should return an Assert overriding default asserts', function () {
+          var fn = function() {
+            this.validate = function() { return 'foobar'; };
+
+            return this;
+          };
+          var Extended = Assert.extend({ Email: fn });
+
+          expect(Extended.prototype.Email).to.eql(fn);
+          expect(Extended.prototype.email).to.eql(fn);
+          expect(Extended.Email().validate()).to.equal('foobar');
+          expect(Extended.email().validate()).to.equal('foobar');
+        } )
       } )
 
       it( 'should be an object', function () {


### PR DESCRIPTION
When we add extra asserts to validator.js, they get added to the list of asserts both in the PascalCase version (e.g. `Foobar`) and in the prettified camelCase version (e.g. `foobar`), and both as a prototype method (e.g. `new Assert().Foobar()`) and static method (e.g. `Assert.foobar()`).

However, when those asserts match the name of an existing assert, the PascalCase version gets correctly overwritten, but the prettified camelCase version, along with the static versions of both, don't.

This leads to an inconsistency in behaviour that might result in unexpected and hard to trace down bugs.

This PR fixes that by applying the new assert to all generated methods. This allows us to extend existing asserts in case we need to add additional clauses or adapt existing ones (e.g. we could extend the Email assert to include special edge cases for specific providers).

Closes https://github.com/guillaumepotier/validator.js/issues/57.

### How to test
```js
// Example of an assert that always returns true:
fn = function() { this.__class__ = 'Email'; this.validate = function(value) { return true; }; return this; }

// Overwriting the Email assert to use that custom assert that always returns true:
Extended = Assert.extend({ Email: fn });

// Should throw as before:
Assert.Email().check('foo');
Assert.email().check('foo');
new Assert().Email().check('foo');
new Assert().email().check('foo');

// Should return a Violation as before:
Assert.Email().validate('foo');
Assert.email().validate('foo');
new Assert().Email().validate('foo');
new Assert().email().validate('foo');

// Static methods were still using the original assert, this PR fixes them to use the new one instead.
// Should throw/return a Violation on master
// Should return true with this PR:
Extended.Email().check('foo');
Extended.email().check('foo');
Extended.Email().validate('foo');
Extended.email().validate('foo');

// Prettified camelCase methods were still using the original assert, this PR fixes them to use the new one instead.
// Should throw/return a Violation on master
// Should return true with this PR:
new Extended().email().check('foo');
new Extended().email().validate('foo');

// PascalCase methods were already being overwritten.
// Should use the new assert both on master and with this PR:
new Extended().Email().check('foo');
new Extended().Email().validate('foo');
```