### PR TITLE
Fix travis build

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,13 +21,13 @@
     "url": "https://github.com/guillaumepotier/validator.js"
   },
   "devDependencies": {
-    "mocha": "*",
     "expect.js": "*",
     "grunt": "~0.4.2",
-    "grunt-contrib-uglify": "~1.0.1",
     "grunt-contrib-clean": "~0.5.0",
+    "grunt-contrib-uglify": "~1.0.1",
+    "grunt-npm2bower-sync": "~0.3.0",
     "grunt-replace": "~0.5.1",
-    "grunt-npm2bower-sync": "~0.3.0"
+    "mocha": "~3.5.3"
   },
   "scripts": {
     "build": "grunt build",


### PR DESCRIPTION
The latest version of mocha is using syntax (`const`) that the target node version (v0.11) used in TravisCI doesn't support yet.

So we need to get the latest mocha version that doesn't have that change yet (v3), so that the build can pass again.